### PR TITLE
Ensured aborted transactions are rolled back so that the connection c…

### DIFF
--- a/services/AccountServiceImpl.py
+++ b/services/AccountServiceImpl.py
@@ -57,6 +57,7 @@ def registerUserImpl(name: str, date_of_birth: datetime, email: str, password: s
             error(f'CreateUser: {e}')
             response.status = False
             response.account_id = None
+            conn.rollback();
 
     accountServiceConnectionPool.release_to_connection_pool(conn, cur)
     return response


### PR DESCRIPTION
…an still subsequently be used - in registration. Otherwise if the connections with aborted transactions are reused from the connection pool, following operations may not work as intended and errors may occur. Closes #22.