### PR TITLE
add constant CONCURRENCY_SIZE

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,6 +3,8 @@ import os
 
 from dotenv import load_dotenv
 
+CONCURRENCY_SIZE = 16
+
 
 def GetConnectionString():
     load_dotenv()

--- a/utils/thread_execute.py
+++ b/utils/thread_execute.py
@@ -1,8 +1,10 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
+from utils import CONCURRENCY_SIZE
+
 # TODO: Allocate executor for each services
-executor = ThreadPoolExecutor(16, 'worker_')
+executor = ThreadPoolExecutor(CONCURRENCY_SIZE, 'worker_')
 
 
 def shutdown_thread_pool():


### PR DESCRIPTION
to centralise the value of concurrency at different places (thread pool, connection pool, initialise_connection_pool, shutdown_connection_pool functions)